### PR TITLE
[WIP] Functionality for starting multiple servers / auto port

### DIFF
--- a/src/Pscid/Server.purs
+++ b/src/Pscid/Server.purs
@@ -1,5 +1,7 @@
 module Pscid.Server
        ( restartServer
+       , startServer'
+       , stopServer'
        , module PscIde.Server
        ) where
 
@@ -9,11 +11,47 @@ import Control.Monad.Aff (attempt, Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
+import Control.Alt ( (<|>) )
 import Data.Either (Either(Right, Left))
-import Data.Maybe (Maybe(Nothing))
+import Data.Maybe (Maybe(..), maybe)
 import Node.ChildProcess (CHILD_PROCESS)
+import Node.FS (FS)
+import Node.Process (PROCESS)
 import PscIde (NET)
-import PscIde.Server (startServer, stopServer)
+import PscIde.Command (Message(..))
+import PscIde.Server (startServer, stopServer, ServerStartResult(..), getSavedPort, pickFreshPort, savePort, deleteSavedPort)
+
+stopServer' :: forall eff. Int -> Aff (cp :: CHILD_PROCESS, process :: PROCESS, net :: NET, fs :: FS, err :: EXCEPTION | eff) Unit
+stopServer' port = do
+  dir <- liftEff Process.cwd
+  liftEff (deleteSavedPort dir)
+  stopServer port
+
+startServer' ∷ forall eff. Maybe Int
+  → Aff (cp ∷ CHILD_PROCESS, process :: Process.PROCESS, console ∷ CONSOLE, avar ∷ AVAR, net :: NET, random :: RANDOM, fs :: FS, err :: EXCEPTION | eff) (Either String Int)
+startServer' optPort = do
+  dir <- liftEff Process.cwd
+  port <- liftEff (getSavedPort dir)
+  case optPort <|> port of
+    Just p -> do
+      workingDir <- attempt (PscIde.cwd p)
+      case workingDir of
+        Right (Right (Message dir')) | dir == dir' -> pure (Right p)
+        _ -> launchServer dir
+    Nothing -> launchServer dir
+
+  where
+  launchServer :: String -> Aff (cp ∷ CHILD_PROCESS, process :: Process.PROCESS, console ∷ CONSOLE, avar ∷ AVAR, net :: NET, random :: RANDOM, fs :: FS, err :: EXCEPTION | eff) (Either String Int)
+  launchServer dir = do
+    newPort <- maybe (liftEff pickFreshPort) pure optPort
+    liftEff (savePort newPort dir)
+    r newPort <$> startServer "psc-ide-server" newPort (Just dir)
+    where
+      r newPort (Started _)    = Right newPort
+      r _       (Closed)       = Left "Closed"
+      r _       (StartError s) = Left s
 
 restartServer
   ∷ forall e
@@ -22,6 +60,7 @@ restartServer
           , console ∷ CONSOLE , avar ∷ AVAR
           , process ∷ Process.PROCESS | e) Unit
 restartServer port = do
+  dir <- liftEff Process.cwd
   attempt (stopServer port)
   r ← attempt (startServer "psc-ide-server" port Nothing)
   liftEff case r of


### PR DESCRIPTION
See branch of purescript-psc-ide re approach etc., and atom plugin doing the same thing, namely saving the port on startup to a dot file in the working directory, checking that on start to use existing server, and generating random new port instead of fixed default port.

Interesting things re pscid
- The `-p` command line option, I interpreted this as over-riding any saved port; but if absent, generate new port
- Now cares about current working directory directly (as it must check the file) - previously would use the current directory by default, but might also connect to an existing server in a _different_ directory
- In atom plugin I'm only removing the saved port if I created it, here I think it's unconditional on exit
- There was a restart attempt on startup,  not quite clear on the purpose of this; temporarily this is removed but would be good to understand in order to maintain behaviour correctly
