### PR TITLE
Handle ctrl+c correctly

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -126,6 +126,8 @@ keyHandler stateRef k = do
           catchLog "Couldn't apply suggestion." (runST (applySuggestions [e]))
     Key {ctrl: false, name: "q", meta: false, shift: false} →
       liftEff (log "Bye!" <* runAff exit exit (stopServer' port))
+    Key {ctrl: true, name: "c", meta: false, shift: false} →
+      liftEff (log "Press q to exit")
     Key {ctrl, name, meta, shift} →
       liftEff (log name)
   where

--- a/src/Pscid/Keypress.js
+++ b/src/Pscid/Keypress.js
@@ -12,9 +12,6 @@ exports.onKeypress = function(cb){
   return function(){
     process.stdin.on('keypress', function (ch, key){
       if (key) {
-        if (key.ctrl && key.name == 'c') {
-          process.exit();
-        }
         cb(key)();
       }
     });


### PR DESCRIPTION
Before, if you hit ctrl+c, it would quit and leave psc-ide-server running. When you then restarted pscid, it would crash because it could not connect to psc-ide-server.

New behavior: tell the user to hit `q` instead.