### PR TITLE
Handle added file

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -11,7 +11,10 @@ exports.gaze = function(globs, cb){
     var watched = watcher.watched();
 
     watcher.on('changed', function(filepath) {
-      console.log(filepath);
+      cb(filepath)();
+    });
+
+    watcher.on('added', function(filepath) {
       cb(filepath)();
     });
   });

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -92,7 +92,7 @@ main = launchAffVoid do
             Process.exit 1
       liftEff do
         runEffFn2 gaze
-          (concatMap (fileGlob directory) sourceDirectories)
+          (concatMap fileGlob sourceDirectories)
           (\d → runPscid (triggerRebuild stateRef d) config')
         clearConsole
         initializeKeypresses
@@ -101,11 +101,11 @@ main = launchAffVoid do
         startScreen
     _ → liftEff (log "Failed to start psc-ide-server")
 
--- | Given a base directory and a directory, appends the globs necessary to
--- | match all PureScript and JavaScript source files inside that directory
-fileGlob ∷ String → String → Array String
-fileGlob base dir =
-  let go x = base <> "/" <> dir <> "/**/*" <> x
+-- | Given a directory, appends the globs necessary to match all PureScript and
+-- | JavaScript source files inside that directory
+fileGlob ∷ String → Array String
+fileGlob dir =
+  let go x = dir <> "/**/*" <> x
   in go <$> [".purs", ".js"]
 
 keyHandler ∷ Ref State → Key → Pscid Unit


### PR DESCRIPTION
Currently `pscid` only handles file change, every time I added a new `.purs` file, I need to restart `pscid`. `b` doesn't help though.

This PR handles `added` event of gaze. However, `added` event is not fired when using absolute paths.
See https://github.com/shama/gaze/issues/84 https://github.com/shama/gaze/issues/205

So I removed `base` from `fileGlob`.

This is still no perfect, because `RebuildCmd` doesn't imply `Load`, I have to press `b` to get added file loaded. I can add a `triggerLoadAndRebuild` function if you agree. Let me know what do you think.