### PR TITLE
remove duplicated build in mkCommand

### DIFF
--- a/src/Pscid/Options.purs
+++ b/src/Pscid/Options.purs
@@ -77,8 +77,8 @@ mkCommand cmd = do
   pscidSpecific ← hasNamedScript ("pscid:" <> cmd)
   namedScript   ← hasNamedScript cmd
 
-  let specificCommand = guard pscidSpecific $> "npm run build -s pscid:"
-      buildCommand    = guard namedScript   $> "npm run build -s "
+  let specificCommand = guard pscidSpecific $> "npm run -s pscid:"
+      buildCommand    = guard namedScript   $> "npm run -s "
       pulpCommand     = pulpCmd <> " "
 
   pure $ fromMaybe pulpCommand (specificCommand <|> buildCommand) <> cmd


### PR DESCRIPTION
With pscid-2.5, when pressing `b`, the command becomes 

`npm run build -s pscid:build` or `npm run build -s build` which is not correct