### PR TITLE
Fixed pscid --include behaviour.

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -32,7 +32,7 @@ import PscIde.Command (Command(..), Message(..))
 import Pscid.Console (owl, clearConsole, suggestionHint, startScreen)
 import Pscid.Error (catchLog, noSourceDirectoryError)
 import Pscid.Keypress (Key(..), onKeypress, initializeKeypresses)
-import Pscid.Options (CLICommand, PscidSettings, optionParser)
+import Pscid.Options (CLICommand, PscidSettings, optionParser, printCLICommand)
 import Pscid.Process (execCommand)
 import Pscid.Psa (filterWarnings, PsaError, parseErrors, psaPrinter)
 import Pscid.Server (restartServer, startServer', stopServer')
@@ -116,9 +116,9 @@ keyHandler stateRef k = do
   {port, buildCommand, outputDirectory, testCommand} ← ask
   case k of
     Key {ctrl: false, name: "b", meta: false, shift: false} →
-      liftEff (execCommand "Build" $ show buildCommand)
+      liftEff (execCommand "Build" $ printCLICommand buildCommand)
     Key {ctrl: false, name: "t", meta: false, shift: false} →
-      liftEff (execCommand "Test" $ show testCommand)
+      liftEff (execCommand "Test" $ printCLICommand testCommand)
     Key {ctrl: false, name: "r", meta: false, shift: false} → liftEff do
       clearConsole
       catchLog "Failed to restart server" $ launchAffVoid do
@@ -157,7 +157,7 @@ triggerRebuild stateRef file = do
           Nothing → pure unit
           Just s → suggestionHint
         when (testAfterRebuild && isRight errs)
-          (execCommand "Test" $ show testCommand)
+          (execCommand "Test" $ printCLICommand testCommand)
 
 changeExtension ∷ String → String → String
 changeExtension s ex =

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -32,7 +32,7 @@ import PscIde.Command (Command(..), Message(..))
 import Pscid.Console (owl, clearConsole, suggestionHint, startScreen)
 import Pscid.Error (catchLog, noSourceDirectoryError)
 import Pscid.Keypress (Key(..), onKeypress, initializeKeypresses)
-import Pscid.Options (PscidSettings, optionParser)
+import Pscid.Options (CLICommand, PscidSettings, optionParser)
 import Pscid.Process (execCommand)
 import Pscid.Psa (filterWarnings, PsaError, parseErrors, psaPrinter)
 import Pscid.Server (restartServer, startServer', stopServer')
@@ -116,9 +116,9 @@ keyHandler stateRef k = do
   {port, buildCommand, outputDirectory, testCommand} ← ask
   case k of
     Key {ctrl: false, name: "b", meta: false, shift: false} →
-      liftEff (execCommand "Build" buildCommand)
+      liftEff (execCommand "Build" $ show buildCommand)
     Key {ctrl: false, name: "t", meta: false, shift: false} →
-      liftEff (execCommand "Test" testCommand)
+      liftEff (execCommand "Test" $ show testCommand)
     Key {ctrl: false, name: "r", meta: false, shift: false} → liftEff do
       clearConsole
       catchLog "Failed to restart server" $ launchAffVoid do
@@ -157,7 +157,7 @@ triggerRebuild stateRef file = do
           Nothing → pure unit
           Just s → suggestionHint
         when (testAfterRebuild && isRight errs)
-          (execCommand "Test" testCommand)
+          (execCommand "Test" $ show testCommand)
 
 changeExtension ∷ String → String → String
 changeExtension s ex =
@@ -196,9 +196,9 @@ foreign import gaze
       Unit
 
 ask ∷ Pscid { port ∷ Int
-             , buildCommand ∷ String
+             , buildCommand ∷ CLICommand
              , outputDirectory ∷ String
-             , testCommand ∷ String
+             , testCommand ∷ CLICommand
              , testAfterRebuild ∷ Boolean
              , sourceDirectories ∷ Array String
              , censorCodes ∷ Array String

--- a/src/Pscid/Options.purs
+++ b/src/Pscid/Options.purs
@@ -1,18 +1,19 @@
 module Pscid.Options where
 
 import Prelude
+
 import Control.Alternative ((<|>))
-import Control.Monad.Eff.Console as Console
-import Data.Array as Array
 import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console as Console
 import Control.Monad.Eff.Exception (catchException)
 import Control.MonadZero (guard)
 import Data.Array (filter, filterA)
+import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Int (fromNumber)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
-import Data.String (Pattern(..), split, null)
+import Data.String (Pattern(..), joinWith, null, split)
 import Global (readInt)
 import Node.FS (FS)
 import Node.Platform (Platform(..))
@@ -23,9 +24,9 @@ import Pscid.Util ((∘))
 
 newtype PscidSettings a = PscidSettings
   { port              ∷ a
-  , buildCommand      ∷ String
+  , buildCommand      ∷ CLICommand
   , outputDirectory   ∷ String
-  , testCommand       ∷ String
+  , testCommand       ∷ CLICommand
   , testAfterRebuild  ∷ Boolean
   , sourceDirectories ∷ Array String
   , censorCodes       ∷ Array String
@@ -38,9 +39,9 @@ type PscidOptions = PscidSettings (Maybe Int)
 defaultOptions ∷ PscidOptions
 defaultOptions = PscidSettings
   { port: Nothing
-  , buildCommand: pulpCmd <> " build"
+  , buildCommand: PulpCommand (pulpCmd <> " build") []
   , outputDirectory: "output"
-  , testCommand: pulpCmd <> " test"
+  , testCommand: PulpCommand (pulpCmd <> " test") []
   , testAfterRebuild: false
   , sourceDirectories: []
   , censorCodes: []
@@ -72,16 +73,50 @@ mkDefaultOptions =
       <*> mkCommand "test"
       <*> scanDefaultDirectories
 
-mkCommand ∷ ∀ e. String → Eff (fs ∷ FS | e) String
+type IncludePath = String
+
+data CLICommand
+  = NamedScriptSpecificCommand String
+  | NamedScriptCommand String
+  | PulpCommand String (Array IncludePath)
+
+instance showCLICommand :: Show CLICommand where
+  show = case _ of
+    NamedScriptSpecificCommand str -> str
+    NamedScriptCommand str -> str
+    PulpCommand str includesArr ->
+      if Array.null includesArr then
+        str
+      else
+        str <> " -I " <> (joinWith ":" includesArr)
+
+-- | If the command is a PulpCommand (eg. "pulp build"), then the array of
+-- | include paths is set. If the command is an NPM script, the command is
+-- | left unchanged. This is because it's impossible to guarantee that the NPM
+-- | script directly executes "pulp build" (it may execute another script), and
+-- | therefore we cannot simply append the includes onto the end of the command.
+setCommandIncludes :: Array IncludePath -> CLICommand -> CLICommand
+setCommandIncludes includesArr cmd = case cmd of
+  PulpCommand str _ -> PulpCommand str includesArr
+  _ -> cmd
+
+mkCommand ∷ ∀ e. String → Eff (fs ∷ FS | e) CLICommand
 mkCommand cmd = do
   pscidSpecific ← hasNamedScript ("pscid:" <> cmd)
   namedScript   ← hasNamedScript cmd
 
-  let specificCommand = guard pscidSpecific $> "npm run -s pscid:"
-      buildCommand    = guard namedScript   $> "npm run -s "
-      pulpCommand     = pulpCmd <> " "
+  let specificCommand =
+        guard pscidSpecific
+          $> NamedScriptSpecificCommand ("npm run -s pscid:" <> cmd)
 
-  pure $ fromMaybe pulpCommand (specificCommand <|> buildCommand) <> cmd
+      buildCommand =
+        guard namedScript
+          $> NamedScriptCommand ("npm run -s " <> cmd)
+
+      pulpCommand =
+        PulpCommand (pulpCmd <> " " <> cmd) []
+
+  pure $ fromMaybe pulpCommand (specificCommand <|> buildCommand)
 
 optionParser ∷ ∀ e. Eff (console ∷ Console.CONSOLE, fs ∷ FS | e) PscidOptions
 optionParser =
@@ -121,18 +156,19 @@ buildOptions
   → Eff (fs ∷ FS | e) PscidOptions
 buildOptions port testAfterRebuild includes outputDirectory censor = do
   defaults ← unwrap <$> mkDefaultOptions
-  let sourceDirectories =
-        if null includes
-        then defaults.sourceDirectories
-        else filter (not null) (split (Pattern ";") includes)
+  let includesArr = filter (not null) (split (Pattern ";") includes)
+      sourceDirectories = defaults.sourceDirectories <> includesArr
       censorCodes = filter (not null) (split (Pattern ",") censor)
+      buildCommand = setCommandIncludes includesArr defaults.buildCommand
+      testCommand = setCommandIncludes includesArr defaults.testCommand
+
   pure (wrap { port: fromNumber (readInt 10 port)
              , testAfterRebuild
              , sourceDirectories
              , censorCodes
-             , buildCommand: defaults.buildCommand
+             , buildCommand: buildCommand
              , outputDirectory
-             , testCommand: defaults.testCommand
+             , testCommand: testCommand
              })
 
 foreign import hasNamedScript ∷ ∀ e. String → Eff (fs ∷ FS | e) Boolean


### PR DESCRIPTION
Added an ADT (CLICommand) to represent the possible command types:
NamedScriptSpecificCommand ("pscid:" script in package.json),
NamedScriptCommand (script in package.json), and
PulpCommand (eg. "pulp build").

Only the PulpCommand data constructor has an associated array of
include paths; the reasoning is described in a comment
(Options.purs:93).

These commands are transformed into the appropriate string command via
a Show instance.