### PR TITLE
Use purescript-optparse over yargs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,13 +15,14 @@
     "purescript-transformers": "^4.1.0",
     "purescript-psc-ide": "^13.0.0",
     "purescript-psa-utils": "^5.1.0",
-    "purescript-yargs": "^4.0.0",
+    "purescript-optparse": "^2.0.0",
     "purescript-node-streams": "^4.0.0",
     "purescript-node-process": "^6.0.0",
     "purescript-suggest": "^4.0.0",
     "purescript-arrays": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^4.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-debug": "^4.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -22,15 +23,6 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "app-cache-dir": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.3.1.tgz",
-      "integrity": "sha512-zJ/Gj1wEQ7Z9yuLID6XhAaSbWGkGVEwMkqcrv5/Jv0GCT19UpDKkyybq84SOWBi+WzT7Y3mihYXGtMnK7Z3DMQ==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.2"
       }
     },
     "append-type": {
@@ -56,16 +48,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -75,45 +57,21 @@
         "concat-map": "0.0.1"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
-    },
     "build-purescript": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.2.3.tgz",
-      "integrity": "sha512-oIBeOxbEHG8don4jqxCMhZxoXCqk21jIqN+a9U/8jiiwYOAS6KcssxcTklhE+LzEIsBx/hh8cObQ5Lupos/mVw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.4.1.tgz",
+      "integrity": "sha512-wHoafIs4c1yDJspybVilXRQZUauaxdGPkZU0HdJdu968uei7O4yS/cp/h1O4zIMVDu9MN6/sYDCLnhQA3iLAYA==",
       "dev": true,
       "requires": {
-        "download-purescript-source": "^0.4.0",
+        "download-purescript-source": "^0.6.2",
         "feint": "^1.0.2",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "once": "^1.4.0",
-        "rimraf": "^2.6.2",
-        "spawn-stack": "^0.5.0",
-        "zen-observable": "^0.6.1"
+        "rimraf": "^2.6.3",
+        "spawn-stack": "^0.7.0",
+        "zen-observable": "^0.8.13"
       }
     },
     "byline": {
@@ -122,18 +80,13 @@
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
     },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
     "cancelable-pump": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.2.0.tgz",
-      "integrity": "sha1-hlZl1MI6aXiNS830mNt0DxsjDVc=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
+      "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
       "dev": true,
       "requires": {
-        "pump": "^1.0.2"
+        "pump": "^3.0.0"
       }
     },
     "chalk": {
@@ -154,9 +107,9 @@
       "dev": true
     },
     "clean-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-      "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+      "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
       "dev": true
     },
     "cli-cursor": {
@@ -167,33 +120,6 @@
       "requires": {
         "restore-cursor": "^2.0.0"
       }
-    },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -215,12 +141,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -234,95 +154,63 @@
         "which": "^1.2.9"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
     "dl-tar": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.6.0.tgz",
-      "integrity": "sha512-bh6sKubl/RzCNC6v6PEim13GDA0D0OEq8j1yqORFQrVnH8C1aaP2xb4BSRP8VxFPKYVvAi4zzDEBMr72z2M9Wg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.8.0.tgz",
+      "integrity": "sha512-MiuyQYrVwdcUx51XMH7qu/ivm+pD2rNKJ+9vJxYHWaltnE+qYF5VS0kRm3qS/IRzMr5nsgZaCwPuorUWw3nmJQ==",
       "dev": true,
       "requires": {
-        "cancelable-pump": "^0.2.0",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
+        "cancelable-pump": "^0.4.0",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "is-stream": "^1.1.0",
-        "load-request-from-cwd-or-npm": "^2.0.1",
-        "tar-fs": "^1.16.0",
-        "tar-stream": "^1.5.5",
-        "zen-observable": "^0.6.1"
-      }
-    },
-    "dl-tgz": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.6.0.tgz",
-      "integrity": "sha512-pkf0P6EwWfVmpbFTvgfrWOh9JvrCwW/bnx2i+M9ffKfKCP20B/3ZHRL/jGXL8nuZ+TQcI/rsasx1fzjf+expmQ==",
-      "dev": true,
-      "requires": {
-        "dl-tar": "^0.6.0",
-        "is-plain-obj": "^1.1.0",
-        "zen-observable": "^0.6.1"
+        "load-request-from-cwd-or-npm": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "tar": "^4.4.6",
+        "zen-observable": "^0.8.9"
       }
     },
     "download-or-build-purescript": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.9.tgz",
-      "integrity": "sha512-1SOq5zLZd2Nh1bmyQUhMlmZoUxuUMYYTHcyU8kR2Y9nRRiuogEWQcD2+SiJfEl5S6Ap+S4x2hVNP3bbQp0/80g==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.3.4.tgz",
+      "integrity": "sha512-8P4vNgbLTZi07s3uRnUCI+kE7lAERyIexVYwAHsAw7AQhooFnVbypq/yiP1vSZVibQ4Fl74LdOWnJKbqe9Mnow==",
       "dev": true,
       "requires": {
-        "build-purescript": "^0.2.0",
-        "download-purescript": "0.5.0-0",
-        "execa": "^0.10.0",
+        "build-purescript": "^0.4.1",
+        "download-purescript": "^0.8.3",
         "feint": "^1.0.2",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
         "once": "^1.4.0",
-        "prepare-write": "^0.3.1",
-        "spawn-stack": "^0.5.0",
-        "which": "^1.3.0",
-        "zen-observable": "^0.6.0"
-      },
-      "dependencies": {
-        "prepare-write": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
-          "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "inspect-with-kind": "^1.0.2",
-            "is-dir": "^1.0.0",
-            "mkdirp": "^0.5.1"
-          }
-        }
+        "pause-methods": "^1.0.0",
+        "run-in-dir": "^0.3.0",
+        "spawn-stack": "^0.7.0",
+        "which": "^1.3.1",
+        "zen-observable": "^0.8.13"
       }
     },
     "download-purescript": {
-      "version": "0.5.0-0",
-      "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.5.0-0.tgz",
-      "integrity": "sha512-oBjNPPBBB/zcsIvn9VUgL+YnT9E3dSszwISKmPxU4ehIkAisysrII8pvQAoQRxSikppJhmajo/VYEpa5LD0whQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.8.5.tgz",
+      "integrity": "sha512-m2avp1YMDTxZW3mtlG7U09bmgCrLbBIsuBEglywew0uoG7VHVdtOwlTXEdvQQTqpW9iylrz8PokfPlqzc6AYiA==",
       "dev": true,
       "requires": {
-        "dl-tgz": "^0.6.0",
-        "inspect-with-kind": "^1.0.4",
+        "arch": "^2.1.1",
+        "dl-tar": "^0.8.0",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "zen-observable": "^0.6.1"
+        "zen-observable": "^0.8.13"
       }
     },
     "download-purescript-source": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.4.0.tgz",
-      "integrity": "sha512-Y+5VqajGu9uv63XbY7R27UZGplqxQkyYMg52nSBHQMOyML/2TIm4HmP3trTSM2lxFR4yCeKGQgPas35OERCFWg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.6.5.tgz",
+      "integrity": "sha512-RyOSTL7B3qzrhCOfhgzxNrcZD1klFOAJcw2YG345AIB4su1KC4WSk6fzRz3xpg1tp/plr5v8aDlvZy+LDtf6uA==",
       "dev": true,
       "requires": {
-        "dl-tgz": "^0.6.0",
-        "inspect-with-kind": "^1.0.4",
+        "dl-tar": "^0.8.0",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "zen-observable": "^0.6.1"
+        "zen-observable": "^0.8.13"
       }
     },
     "emoji-regex": {
@@ -340,14 +228,6 @@
         "once": "^1.4.0"
       }
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -355,13 +235,13 @@
       "dev": true
     },
     "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -370,76 +250,56 @@
       }
     },
     "executing-npm-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/executing-npm-path/-/executing-npm-path-0.1.0.tgz",
-      "integrity": "sha512-NG/Pw0xD4KBcb5ilpZa57n7U17obIvZX1TCBLdv9M7Jd3wSsfU8BtMSy+EFkx9hhJsnIBBEmaPQd12dXWaxlHA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/executing-npm-path/-/executing-npm-path-1.0.0.tgz",
+      "integrity": "sha512-d/dZlFCLkKm8nwdzpfQ7JBL2BISg4Fu0bVpZ5nacuT3e6DIxYVb+8tx0eQ+jxquvV/8I+VjJ9g6aEAqjukogkw==",
       "dev": true
     },
     "feint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.2.tgz",
-      "integrity": "sha512-PC77rn63FAMGcmHEkuGh4AdofqI6/c/YGjyvLo60mGLcCOHUUzCnKFzoij062piVgBblkl/KlN1vHGVJsK88cg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.3.tgz",
+      "integrity": "sha512-BY1jwDlOx4uA9rtn2H9bZSuHT7yyOtSRDVwUwprRpRXvpm1F73gSGuHznEu50lT6epscULOknphOprG9ljoARg==",
       "dev": true,
       "requires": {
-        "append-type": "^1.0.1"
+        "append-type": "^1.0.2"
       }
     },
-    "file-to-tar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.3.1.tgz",
-      "integrity": "sha512-bFYkxQR2weH7Bgdj6Dxuo+0rRZagcqY0uuu2CcXUdrOp8TFfkGYEdHy3uSqLiwhkXCcFFDk0584bdIyyEvJKBA==",
+    "file-to-npm-cache": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/file-to-npm-cache/-/file-to-npm-cache-0.1.0.tgz",
+      "integrity": "sha512-2/aq3BD1pkd6b4pafmTaO8EzRCiQKfFmJxg+zKAdDMAcqqJMC0nQYcuCU29say0ZTzXxafKXcJB50N+yb0WIoQ==",
       "dev": true,
       "requires": {
-        "cancelable-pump": "^0.4.0",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "is-stream": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "tar-fs": "^1.16.2",
-        "zen-observable": "^0.6.1"
-      },
-      "dependencies": {
-        "cancelable-pump": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
-          "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
+        "npcache": "^1.0.0",
+        "pump": "^3.0.0",
+        "tar": "^4.4.6"
       }
     },
     "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.1.2.tgz",
+      "integrity": "sha512-iSWteWtfNcrWQTkQw8ble2bnonSl7YJImsn9OZKpE2E4IHhXI78eASpDYUljXZZdYj36QsEKjOs/CsiDqmKMJw==",
       "dev": true
     },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+    "find-pkg-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-pkg-dir/-/find-pkg-dir-1.0.1.tgz",
+      "integrity": "sha512-pIXIrZshXst3hpg5nXDYALHlN4ikh4IwoM0QRnMnYIALChamvpPCJS1Mpwp27GpXXTL/647LDS4JkH1yfAKctw==",
+      "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "inspect-with-kind": "^1.0.4"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -454,20 +314,19 @@
         "globule": "^1.0.0"
       }
     },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -487,21 +346,20 @@
         "minimatch": "~3.0.2"
       }
     },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+    "import-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-package/-/import-package-1.0.0.tgz",
+      "integrity": "sha512-EEDT2ucOWI/9z/h2mLTRkkusM30/pxSoBT6YvomYpEb/UGll6wOvdFagYraCSBHD+dZSKoVFNYCAgC3V7Nvf1Q==",
+      "dev": true,
+      "requires": {
+        "load-from-cwd-or-npm": "^3.0.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -527,75 +385,52 @@
       }
     },
     "install-purescript": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.4.0.tgz",
-      "integrity": "sha512-hXfy12CP/aSCxEhx75kA2jTsbUrkQYFwbolNIrFcFVaiSYc3GpEcAsLqSuijzMCtfxAq+2S6Uw5o6QrVVNVpwQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.7.0.tgz",
+      "integrity": "sha512-AOmIq8rPEOLn5Bo8RQngvDXWeo6USKIt+28UhcAmQJNvj63MqdNBIQRTgNyypbsniv7d7VWjz53pw2+kTgh3mg==",
       "dev": true,
       "requires": {
-        "app-cache-dir": "^0.3.0",
-        "arch": "^2.1.0",
-        "download-or-build-purescript": "^0.0.9",
-        "execa": "^0.10.0",
-        "feint": "1.0.2",
-        "file-to-tar": "^0.3.1",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
+        "arch": "^2.1.1",
+        "download-or-build-purescript": "^0.3.4",
+        "file-to-npm-cache": "^0.1.0",
+        "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
-        "once": "^1.4.0",
-        "prepare-write": "^1.0.0",
-        "readdir-clean": "^1.0.0",
-        "rimraf": "^2.6.2",
-        "tar-to-file": "^0.4.0",
-        "tilde-path": "^2.0.0",
-        "truncated-list": "^1.0.1",
-        "zen-observable": "^0.6.1"
+        "npcache": "^1.0.2",
+        "pump": "^3.0.0",
+        "run-in-dir": "^0.3.0",
+        "tar": "^4.4.8",
+        "zen-observable": "^0.8.14"
       }
     },
     "install-purescript-cli": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.3.0.tgz",
-      "integrity": "sha512-fxxJ2nnKfDHli530XVz7w5bd5I7UKODtVjMLJuvpOHPSqPfHgOPqHat2vjPTqaW5B4sHt3NYGopvt/fYPfwl2A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.4.2.tgz",
+      "integrity": "sha512-y62GvwsMksz7aSJQsK2pPelmBByp0eDgpI+uFheEU05wpekM6WtCgq7WkTAc+Ar/nt+7Y5lYzGOqSOWnGAEIBQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "install-purescript": "^0.4.0",
-        "log-symbols": "^2.2.0",
-        "log-update": "^2.3.0",
+        "chalk": "^2.4.2",
+        "filesize": "^4.1.2",
+        "install-purescript": "^0.7.0",
+        "log-symbols": "^3.0.0",
+        "log-update": "^3.2.0",
         "minimist": "^1.2.0",
         "ms": "^2.1.1",
-        "neat-frame": "^1.0.1",
-        "neat-stack": "^1.0.0",
+        "neat-stack": "^1.0.1",
+        "npcache": "^1.0.2",
         "once": "^1.4.0",
         "platform-name": "^1.0.0",
-        "size-rate": "^0.1.0",
-        "tilde-path": "^2.0.0",
-        "tty-truncate": "^1.0.0",
+        "size-rate": "^0.3.1",
+        "tilde-path": "^3.0.0",
+        "tty-truncate": "^1.0.3",
+        "tty-width-frame": "^1.0.2",
         "vertical-meter": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-dir/-/is-dir-1.0.0.tgz",
-      "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8=",
-      "dev": true
-    },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -606,24 +441,13 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "junk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
-      "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ=",
-      "dev": true
     },
     "keypress": {
       "version": "0.2.1",
@@ -636,53 +460,25 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "load-from-cwd-or-npm": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/load-from-cwd-or-npm/-/load-from-cwd-or-npm-2.2.2.tgz",
-      "integrity": "sha512-Ox0Cl1RfKMKrwqhBqYADWeFspY28bhlaJVe08GJqYtVYoE0kyAnWBOnw3V/+HDoeWb7o33X/ZUcvamIlJ4O4Gg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/load-from-cwd-or-npm/-/load-from-cwd-or-npm-3.0.1.tgz",
+      "integrity": "sha512-mzcNbKt0k7P6lHS9Qp6hinEvW0wWm7q7BKYh6NISVWZJ3+l3IbrJwSpBs+7bWtd1Y088+w42ZLXytyyEg8SCIQ==",
       "dev": true,
       "requires": {
         "inspect-with-kind": "^1.0.4",
-        "npm-cli-dir": "^2.0.1",
+        "npm-cli-dir": "^3.0.0",
         "optional": "^0.1.4",
-        "resolve-from-npm": "^2.0.4"
-      }
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "resolve-from-npm": "^3.1.0"
       }
     },
     "load-request-from-cwd-or-npm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/load-request-from-cwd-or-npm/-/load-request-from-cwd-or-npm-2.0.1.tgz",
-      "integrity": "sha512-RMDblVBrhyatt2KBScYzbPZrg2KGOryEdcAXIF3Jh3nqcE1awqUtJABwkPv1UrC802QFFxn/mn10m9dHN+fXrQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/load-request-from-cwd-or-npm/-/load-request-from-cwd-or-npm-3.0.0.tgz",
+      "integrity": "sha512-UsYAoXQV3UeL75Rl5IppBGOcKK5iKpvWooUPUHdxcQg9IKIkfg6PWpBQ4EhoRxTioIqrz587Ur2+c2uB/KGpng==",
       "dev": true,
       "requires": {
-        "load-from-cwd-or-npm": "^2.2.1"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "load-from-cwd-or-npm": "^3.0.0"
       }
     },
     "lodash": {
@@ -691,73 +487,30 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       }
     },
     "log-update": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.2.0.tgz",
+      "integrity": "sha512-KJ6zAPIHWo7Xg1jYror6IUDFJBq1bQ4Bi4wAEp2y/0ScjBBVi/g0thr0sUVhuvuXauWzczt7T2QHghPDNnKBuw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
-          }
-        }
-      }
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "^1.0.0"
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -772,6 +525,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -796,46 +568,6 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
-    "neat-frame": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-1.0.2.tgz",
-      "integrity": "sha512-V1aFRKYLeHt8j+/Zcth3wRlQVd5jiWlXyT1McmW6dJvE08wxZXUp38pwFhoIMSr4f3N2UEcJvR1z0VKrSCwYsQ==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.5",
-        "string-width": "^2.1.1",
-        "term-size": "^1.2.0",
-        "wrap-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
-          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
-          }
-        }
-      }
-    },
     "neat-stack": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-1.0.1.tgz",
@@ -852,49 +584,81 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+    "npcache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npcache/-/npcache-1.0.2.tgz",
+      "integrity": "sha512-h42LqKZvSbykPoCyAwEKbJAXUpt1SZ7O8GvA0XRqb26VtWQuKLJtp+Rt4jqkq1Y+ZRErINdyeZ3Ijc5lDtqkSg==",
+      "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "npm-cache-path": "^2.0.0",
+        "reject-unsatisfied-npm-version": "^1.0.0",
+        "resolve-from-npm": "^3.1.0"
+      }
+    },
+    "npm-cache-env": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-cache-env/-/npm-cache-env-2.0.0.tgz",
+      "integrity": "sha512-t5cz/NY4IPmiKBRFry3U3M8Ypwdx4LJ3w7te/49LWB2R4wPf5QAAGB1zNoH9IbGtC/wiOeE8b/HsoG2lLAOYaQ==",
+      "dev": true
+    },
+    "npm-cache-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-cache-path/-/npm-cache-path-2.0.0.tgz",
+      "integrity": "sha512-7OJzaenruC1PffVJ7onG0u4aTQLaykT4gF5n61j9fot58J4ppoglkrv+pY4BsFR2drPWb6vbEpJH7/Xviv7h+Q==",
+      "dev": true,
+      "requires": {
+        "npm-cache-env": "^2.0.0"
       }
     },
     "npm-cli-dir": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-cli-dir/-/npm-cli-dir-2.0.2.tgz",
-      "integrity": "sha512-ibO7mB5Na7yv4fFTi39y3dKeK0D51ttyldqqOZKR9GU0Qwr0FFycQhXIliwqzNCVRkNi/iTG0D9WIVt7pP+vGQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-cli-dir/-/npm-cli-dir-3.0.1.tgz",
+      "integrity": "sha512-t9V9Gz/Q5a5KOSynLpKKnLxJzWLnHtAZvaLmNSbNeNR+qEpCmu/n5J74lyz4QQ/XIGEEYWIoVXR8scqbUWaMrQ==",
       "dev": true,
       "requires": {
-        "npm-cli-path": "^2.0.1"
+        "find-pkg-dir": "^1.0.1",
+        "npm-cli-path": "^3.1.0"
       }
     },
     "npm-cli-path": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/npm-cli-path/-/npm-cli-path-2.0.5.tgz",
-      "integrity": "sha512-Mdd8f1l0o7KUkL8Mty5XbaJVD6hQ/Kq10AFgyjhHg6d/0KHXc4p/O6hPWXSmoJ/RXyzPKIqDCXM1zq46i+Yfeg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/npm-cli-path/-/npm-cli-path-3.1.2.tgz",
+      "integrity": "sha512-JdiFz8kpCf9WD01zRx5u29EP5UYjKp9osSVMflPkamlplgsuaagkwqY3JpzDySl/VDpGUva8q8YoSG6AatFkIg==",
       "dev": true,
       "requires": {
-        "executing-npm-path": "^0.1.0",
-        "real-executable-path": "^2.0.2",
-        "win-user-installed-npm-cli-path": "^2.0.2"
+        "executing-npm-path": "^1.0.0",
+        "which": "^1.3.1",
+        "win-user-installed-npm-cli-path": "^3.0.0"
+      }
+    },
+    "npm-cli-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-cli-version/-/npm-cli-version-1.0.0.tgz",
+      "integrity": "sha512-VqqnMzMfcZ0UZFDki7ZR8E4U8Pz7VbTOGSMk8KJbQ+oUlJlon8IXhb6BIdMJClRArHn216useYM1kvqgZmDvtQ==",
+      "dev": true,
+      "requires": {
+        "npm-cli-dir": "^3.0.0"
       }
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
     },
-    "number-is-nan": {
+    "npm-version-compare": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "resolved": "https://registry.npmjs.org/npm-version-compare/-/npm-version-compare-1.0.1.tgz",
+      "integrity": "sha512-X+/Oz2OkF6KzMqyFyNBV5MC1ScPxtl5bJTkUcIp9Bz5Wv2Yf8uqDIq+vu+/gy2DRb11Q2Z6jfHbav7Ux0t99JQ==",
+      "dev": true,
+      "requires": {
+        "import-package": "^1.0.0",
+        "inspect-with-kind": "^1.0.5",
+        "npm-cli-version": "^1.0.0"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -919,80 +683,11 @@
       "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
       "dev": true
     },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "requires": {
-        "p-try": "^1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "^1.1.0"
-      }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1002,25 +697,27 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+    "pause-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pause-fn/-/pause-fn-1.0.0.tgz",
+      "integrity": "sha512-23uUK11+go9zE7ij4Qh45HPvqanTt22viyNsHnWrRFVgcT5TV4MFtfMhx/wL2aMt0LYbqTsJJZgG3V4C57+NQw==",
+      "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "inspect-with-kind": "^1.0.5"
       }
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    "pause-methods": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pause-methods/-/pause-methods-1.0.0.tgz",
+      "integrity": "sha512-RA8T1+kt1wbD8p0y9/x0BuCMBwNRJzp08euseZ7ZSLGeBUSNHh4yLIsq9J+7fCSDAwnHTjQPSzShwoFnBj0QNQ==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.5",
+        "pause-fn": "^1.0.0"
+      }
     },
     "platform-name": {
       "version": "1.0.0",
@@ -1031,31 +728,10 @@
         "inspect-with-kind": "^1.0.4"
       }
     },
-    "prepare-write": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-1.0.2.tgz",
-      "integrity": "sha512-3g6wGYFExqBDGw1P9oYrKbeSymmYcYIxiOlWzyIV4nOqrf5jiiFE8N7eU53a8UBtW8gsSwk2YQBz67VeDEafQA==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.5",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -1063,12 +739,12 @@
       }
     },
     "purescript": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.12.3.tgz",
-      "integrity": "sha512-V2r6K7hs965/4VEdQi9edpRi6diNbXXYhh1KeduuiWAMPVqG4dAxUrFQZovrlpWul9CfMisFLRCCgIB0lXETiw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.12.5.tgz",
+      "integrity": "sha512-L0N0KrRgZm8pXYqT8Dc5m6BzjnYvkOaxx9Tms874NUivm8DYSs3oLtDrnNM8cVrjCCXCvS0g8l73CKNymaL6qw==",
       "dev": true,
       "requires": {
-        "install-purescript-cli": "^0.4.0 || ^0.3.0"
+        "install-purescript-cli": "^0.4.0"
       }
     },
     "rate-map": {
@@ -1080,102 +756,24 @@
         "append-type": "^1.0.1"
       }
     },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+    "reject-unsatisfied-npm-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reject-unsatisfied-npm-version/-/reject-unsatisfied-npm-version-1.0.0.tgz",
+      "integrity": "sha512-8cl35x8i3W1+RubvIq9CM7fJkdMwBOdjne4b7eFBoo4vvN1QoXbgusQw6VVv2DBmm6NDyMhUmp9FBxaMWU9s7Q==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "npm-cli-version": "^1.0.0",
+        "npm-version-compare": "^1.0.0"
       }
     },
-    "readdir-clean": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-1.0.1.tgz",
-      "integrity": "sha512-qeAvS+0//+S20//w1qozhLO1xPNNWWei5qzNPvYgYuKUmaHky0n3bweB/vBIi/xxjcUCOfL0r5lOPSeNazZ6Yg==",
-      "dev": true,
-      "requires": {
-        "junk": "^2.1.0"
-      }
-    },
-    "real-executable-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/real-executable-path/-/real-executable-path-2.0.2.tgz",
-      "integrity": "sha512-fRv44zvrzFeItoj/f/SNBqO/VWUHSZeqQ28oPOzd6weXaiRG6OVGu7UrHe6pY8JlXeoe/7gWYv6kOFHmHk4EFw==",
-      "dev": true,
-      "requires": {
-        "real-executable-path-callback": "^2.1.2"
-      }
-    },
-    "real-executable-path-callback": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/real-executable-path-callback/-/real-executable-path-callback-2.1.2.tgz",
-      "integrity": "sha512-dyOgKEhLKNg9tgFPs354X5fQpaAsUT+3dTO3JYoNLdPhMmRDjwwre6zHw58biFMVeFx9yxwI6MC7iMDfxSuMJA==",
+    "resolve-from-npm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-from-npm/-/resolve-from-npm-3.1.0.tgz",
+      "integrity": "sha512-HVhEcznfeFWM7T3HWCT7vCjwkv0R1ruC4Ref5jTlTvz2X8GKeUZTqjvZWlefmKQvQfKYOJhQo90Yjhpcr8aclg==",
       "dev": true,
       "requires": {
         "inspect-with-kind": "^1.0.4",
-        "is-plain-obj": "^1.1.0",
-        "which": "^1.3.0"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
-    },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
-    },
-    "resolve-from-npm": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/resolve-from-npm/-/resolve-from-npm-2.0.4.tgz",
-      "integrity": "sha512-JrwN+SRILVjq/mdPNd6bhoOvYMBFf0CYqvfAgaDGB9dWjyr3XDAe40O2WcxToYWMmbQabM4FM6hHVLcSxBPKOQ==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.3",
-        "npm-cli-dir": "^2.0.2",
-        "resolve-from": "^4.0.0"
+        "npm-cli-dir": "^3.0.0"
       }
     },
     "restore-cursor": {
@@ -1197,6 +795,15 @@
         "glob": "^7.1.3"
       }
     },
+    "run-in-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/run-in-dir/-/run-in-dir-0.3.0.tgz",
+      "integrity": "sha512-5aPpxad3Jq9r6OK6rw+Gs5HVuZsEeQM/M4I9CdCWyThkstLAUCJSc3IRs8dT0p/z9mxAJgU5ELRQL2q/ddY6PQ==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.5"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1204,19 +811,16 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -1224,21 +828,23 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "size-rate": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/size-rate/-/size-rate-0.1.0.tgz",
-      "integrity": "sha512-Yinx2XAfbhJu+Pxz1TD3xFT6nPB54+wyRd4u82Kq+ZqzOtaODYS5/7QJtlOcRxJLUvNXMzJKGvJ/O1KyN/9+hQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/size-rate/-/size-rate-0.3.1.tgz",
+      "integrity": "sha512-gs1+6r1P1w00Qv00qC4Be2pbl70/cIVCtsZJPQhEzH3vNss8QbkGIVh6/SCC7atSlX7hkuwH93TyWL1iyXjurQ==",
       "dev": true,
       "requires": {
-        "filesize": "^3.5.10",
-        "inspect-with-kind": "^1.0.2"
+        "filesize": "^4.1.2",
+        "inspect-with-kind": "^1.0.5"
       }
     },
     "slice-ansi": {
@@ -1250,111 +856,45 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "spawn-stack": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.5.0.tgz",
-      "integrity": "sha512-suwvBV2WNTOYe/TQBoAFrGbdRvo5t/pWYq/vNw24wbSmIJXr/eaadsF+92VyPm2dBYsYwBnsTLhQFCo3EdCA+Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.7.0.tgz",
+      "integrity": "sha512-lV3XTrZqR76y9voQq3g0NfCCd4dylXtgQW+xcoZkRYe/6IZJM20G//s2+4JYojJoHQQKKuoU+lUZkO5/tEJe4A==",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
-        "execa": "^0.10.0",
-        "inspect-with-kind": "^1.0.4",
-        "zen-observable": "^0.6.1"
+        "execa": "^1.0.0",
+        "inspect-with-kind": "^1.0.5",
+        "zen-observable": "^0.8.9"
       }
-    },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^4.1.0"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -1365,127 +905,26 @@
         "has-flag": "^3.0.0"
       }
     },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "dev": true,
-      "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      }
-    },
-    "tar-to-file": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.4.0.tgz",
-      "integrity": "sha512-DFRBSotqmgeMrU/H7z0VIMPv8taOheRUlAhi6Q+r5Xso9xoa5vez/Z3uvASSzuT1dwe2orAdENT7NXlAh1zwvA==",
-      "dev": true,
-      "requires": {
-        "cancelable-pump": "^0.4.0",
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.4",
-        "is-plain-obj": "^1.1.0",
-        "is-stream": "^1.1.0",
-        "tar-fs": "^1.16.2",
-        "tar-stream": "^1.6.1",
-        "zen-observable": "^0.6.1"
-      },
-      "dependencies": {
-        "cancelable-pump": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
-          "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       }
     },
     "tilde-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tilde-path/-/tilde-path-2.0.0.tgz",
-      "integrity": "sha512-3aDt7b/wBbxJjUTMiCW+uu7iqrB6F1DfxSL0qB4biSrP1+knIPveccs7thL34AkzPZ/0T7+oYXZDKiokMc1d6g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tilde-path/-/tilde-path-3.0.0.tgz",
+      "integrity": "sha512-jHGx1beQCxoIuyg1LDKxqL3J0zNA57eGjlXsqtcjj6Q9EKXh4Sz895VxXW/psJW1PYIF79XViZEEWrvmhaZ61g==",
       "dev": true
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
-    },
-    "truncated-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-1.0.1.tgz",
-      "integrity": "sha512-aNcDZ1PfxAtUXXLEmy+m1D465lFv0VgWltGlTWuJuhPh+FGeOiHV9S2DYOD8IEgZU8yOInZBRHVcAts+xIYzew==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.4"
-      }
     },
     "tty-truncate": {
       "version": "1.0.3",
@@ -1497,55 +936,17 @@
         "inspect-with-kind": "^1.0.5",
         "slice-ansi": "^2.0.0",
         "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
-    "util-deprecate": {
+    "tty-width-frame": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "resolved": "https://registry.npmjs.org/tty-width-frame/-/tty-width-frame-1.0.2.tgz",
+      "integrity": "sha512-BZQ4VgFnPiH7WtfcuPTUOctHfUj/KWIPeBGnn8jvGfMz8dQ4NqLAwtlxlfFHr3ZRqyrMSAY3CtDIAnOPLuNO2w==",
+      "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "inspect-with-kind": "^1.0.5",
+        "string-width": "^3.1.0",
+        "wrap-ansi": "^5.0.0"
       }
     },
     "vertical-meter": {
@@ -1565,36 +966,21 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
     "win-user-installed-npm-cli-path": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-2.0.4.tgz",
-      "integrity": "sha512-i+fSInL3Li47P9gGcJabtgvl2+hLmZwMsh4664WWuI1F/pQPtv4XerrOyg8poxvDv4o/QwB60f20MKtIX/CCxQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-3.0.0.tgz",
+      "integrity": "sha512-3b2TY0fmLQmeG3HhHa9I4Rq0ZIJg5SZpr5aB++DuAR1NNO+9ZcMueDZ7XRSynaOyCWTgJDFc+c3tDXaeHSFtAg==",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       }
     },
     "wrappy": {
@@ -1602,54 +988,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-      "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
-    },
     "zen-observable": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.6.1.tgz",
-      "integrity": "sha512-DKjFTL7siVLIUMZOFZ0alqMEdTsXPUxoCZzrvB2tdWEVN/6606Qh1nCfSTCAOZMrtcPzzFI3BXmwBKLAew52NA==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "gaze": "^1.1.3",
     "glob": "^7.1.3",
     "keypress": "^0.2.1",
-    "which": "^1.3.1",
-    "yargs": "^8.0.2"
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "purescript": "^0.12.3",

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,6 +1,0 @@
-module Test.Main where
-
-import Control.Monad.Eff.Console (log)
-
-main = do
-  log "Success"


### PR DESCRIPTION
This lets us drop the outdated dependency on yargs, and get much nicer PureScript-y option parsing.

@i-am-tom @danieljharvey I'm hoping I ported all the option flags faithfully, but maybe you could give this branch a try to make sure I didn't break any of your workflows?