### PR TITLE
Add Spago support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Start `pscid` in a terminal in the root folder of your project.
 
 pscid will show you errors and warnings (one at a time) whenever you save a PureScript source file. This makes for a nice iterative workflow.
 
-Type `b` inside `pscid`'s terminal window to build your project. This looks up the `pscid:build` script inside your package.json, then falls back to the `build` script, and then finally tries `pulp build`.
+Type `b` inside `pscid`'s terminal window to build your project. This looks up the `pscid:build` script inside your package.json, then falls back to the `build` script, and then finally tries `spago/pulp build`.
 
-Type `t` inside `pscid`'s terminal window to test your project. As with building this looks up the `pscid:test` script first, then `test`, then falls back to `pulp test` as a last resort.
+Type `t` inside `pscid`'s terminal window to test your project. As with building this looks up the `pscid:test` script first, then `test`, then falls back to `spago/pulp test` as a last resort.
 
 Type `q` to quit pscid.
 

--- a/src/Pscid/Console.purs
+++ b/src/Pscid/Console.purs
@@ -23,8 +23,8 @@ owl =
 helpText ∷ String
 helpText =
   """
-Press b to run a full build (tries "npm run pscid:build" then "npm run build" then "pulp build")
-Press t to test (tries "npm run pscid:test" then "npm run test" then "pulp test")
+Press b to run a full build (tries "npm run pscid:build" then "npm run build" then "spago/pulp build")
+Press t to test (tries "npm run pscid:test" then "npm run test" then "spago/pulp test")
 Press r to reset
 Press q to quit
   """

--- a/src/Pscid/Options.js
+++ b/src/Pscid/Options.js
@@ -1,15 +1,20 @@
 //module Pscid.Options
 
+exports.isSpagoProject = function(){
+  return function(){
+    try {
+      return fs.existsSync(process.cwd() + '/spago.dhall');
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
 exports.hasNamedScript = function(name){
   return function(){
     try {
       var pjson = require(process.cwd() + '/package.json');
-      if (pjson.scripts && pjson.scripts[name]){
-        return true;
-      }
-      else {
-        return false;
-      }
+      return pjson.scripts && pjson.scripts[name];
     } catch (e) {
       return false;
     }

--- a/src/Pscid/Options.purs
+++ b/src/Pscid/Options.purs
@@ -90,6 +90,7 @@ setCommandIncludes includesArr cmd = case cmd of
 
 mkCommand ∷ String → Effect CLICommand
 mkCommand cmd = do
+  spagoProject ← isSpagoProject
   pscidSpecific ← hasNamedScript ("pscid:" <> cmd)
   namedScript ← hasNamedScript cmd
 
@@ -100,10 +101,13 @@ mkCommand cmd = do
         guard namedScript $> ScriptCommand ("npm run -s " <> cmd)
 
       buildCommand =
-        BuildCommand (pulpCmd <> " " <> cmd) []
+        if spagoProject
+        then BuildCommand (spagoCmd <> " " <> cmd) []
+        else BuildCommand (pulpCmd <> " " <> cmd) []
 
   pure $ fromMaybe buildCommand (npmSpecificCommand <|> npmBuildCommand)
 
+foreign import isSpagoProject ∷ Effect Boolean
 foreign import hasNamedScript ∷ String → Effect Boolean
 foreign import glob ∷ String → Effect (Array String)
 


### PR DESCRIPTION
Closes #50 

When a `spago.dhall` file is detected in the project directory, the build and test commands will use `spago` instead of `pulp`.