### PR TITLE
Remove thunk in `isSpagoProject`

### DIFF
--- a/src/Pscid/Options.js
+++ b/src/Pscid/Options.js
@@ -1,12 +1,10 @@
 //module Pscid.Options
 
 exports.isSpagoProject = function(){
-  return function(){
-    try {
-      return fs.existsSync(process.cwd() + '/spago.dhall');
-    } catch (e) {
-      return false;
-    }
+  try {
+    return fs.existsSync(process.cwd() + '/spago.dhall');
+  } catch (e) {
+    return false;
   }
 }
 


### PR DESCRIPTION
This correctly checks for `spago.dhall` and runs `spago build` and `pulp build` accordingly. (Right now, I think running `isSpagoProject` returns the inner nullary function, which is being coerced to `true` every time.) Fixes #55 