### PR TITLE
Pass follow: true to gaze to follow symlinked directories

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -3,7 +3,7 @@
 var gaze = require('gaze');
 
 exports.gaze = function(globs, cb){
-  gaze(globs, function(err, watcher) {
+  gaze(globs, { follow: true }, function(err, watcher) {
     // Files have all started watching
     // watcher === this
 


### PR DESCRIPTION
Similar to https://github.com/purescript-contrib/pulp/pull/378

When I have a shared folder like
```
sym
├── A.purs
├── B
│   └── B.purs
```
After `cd pkgA/src && ln -s ../../sym .`, `pscid` will only watch for `sym/A.purs` but not `sym/B/B.purs`.

The reason is gaze uses [globule](https://www.npmjs.com/package/globule), which uses [glob](https://www.npmjs.com/package/glob). The readme of glob says
> `**` ... ... does not crawl symlinked directories.

> ### Options
> `follow` Follow symlinked directories when expanding `**` patterns. Note that this can result in a lot of duplicate references in the presence of cyclic links.